### PR TITLE
Add og meta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,7 @@ header:
 
 # Author
 author:
-    email: 
+    email:
     bio:
     job:
     location:
@@ -117,6 +117,8 @@ read_more_message: Continue reading
 go_to_message: Go to the website
 # Your blog cover picture located in folder `source/_images/` (development) or in `source/assets/images/` (production)
 cover_image: cover.jpg
+# Your blog og image, and it will display on share story of facebook.
+og_image:
 # Your favicon located in folder `source/_images/` (development) or in `source/assets/images/` (production)
 favicon:
 # Display an image gallery at the end of a post which have photos variables
@@ -137,4 +139,3 @@ google_analytics_id:
 gravatar_email:
 # Your swiftype install key
 swiftype_install_key:
-

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -48,7 +48,7 @@
     <% if ((theme.og_image) && (theme.og_image.length)) { %>
         <meta property="og:image" content="<%- url_for(theme.image_dir + '/' + theme.og_image) %>" />
     <% } %>
-    <%- open_graph() %>
+    <%- open_graph({title: title}) %>
     <link rel="icon" href="<%- url_for(theme.image_dir + '/' + theme.favicon) %>">
     <% if ((config.feed) && (config.feed.path.length)) { %>
         <link rel="alternative" type="application/atom+xml" title="RSS" href="<%= config.feed.path %>">

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -45,6 +45,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="generator" content="<%= config.title %>">
     <title><%= title %></title>
+    <meta name="author" content="<%= config.author %>">
     <% if ((theme.og_image) && (theme.og_image.length)) { %>
         <meta property="og:image" content="<%- url_for(theme.image_dir + '/' + theme.og_image) %>" />
     <% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -45,8 +45,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="generator" content="<%= config.title %>">
     <title><%= title %></title>
-    <meta name="author" content="<%= config.author %>">
-    <meta name="description" content="<%= config.title %>">
+    <% if ((theme.og_image) && (theme.og_image.length)) { %>
+        <meta property="og:image" content="<%- url_for(theme.image_dir + '/' + theme.og_image) %>" />
+    <% } %>
+    <%- open_graph() %>
     <link rel="icon" href="<%- url_for(theme.image_dir + '/' + theme.favicon) %>">
     <% if ((config.feed) && (config.feed.path.length)) { %>
         <link rel="alternative" type="application/atom+xml" title="RSS" href="<%= config.feed.path %>">


### PR DESCRIPTION
Using [`open_graph()` helper](https://hexo.io/docs/helpers.html#open_graph) to add open graph meta, 
and I add a new property `og_image` to `_config.yml`, it's default image of `og:image`.

Before:
![2015-06-25 1 56 44](https://cloud.githubusercontent.com/assets/8567270/8348374/25de8c28-1b45-11e5-9e7d-6b174f13e18a.png)

After:
![2015-06-25 2 13 48](https://cloud.githubusercontent.com/assets/8567270/8348369/170dd596-1b45-11e5-9d7f-ba086be69a2c.png)

Please check the code, Thanks!
(sorry for my poor English)