### PR TITLE
Initial attempt to add scroll to top button

### DIFF
--- a/layout/_partial/post/actions.ejs
+++ b/layout/_partial/post/actions.ejs
@@ -46,6 +46,11 @@
                 </a>
             </li>
         <% } %>
+        <li class="post-action">
+            <a class="post-action-btn btn btn--default" href="#">
+              <i class="fa fa-list"></i>
+            </a>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
This is for issue #41. There are issues with this pull request (just sharing).

Currently, when "scroll to top" button is clicked, the data-tooltip does not go away until you focus on something else.

I have added commented out code in _tooltip.scss but it's not working right with it uncommented either (the issue then becomes that, although the data-tooltip goes away after clicking, you cannot click / hover on the "scroll to top" button again and get the data-tooltip - not without first focusing on something else).