### PR TITLE
fix missing i18n in archive-post.ejs

### DIFF
--- a/layout/_partial/archive-post.ejs
+++ b/layout/_partial/archive-post.ejs
@@ -4,7 +4,7 @@
 %>
 <div id="archives" class="main-content-wrap">
     <form id="filter-form" action="#">
-        <input name="date" type="text" class="form-control input--xlarge" placeholder="Search a date" autofocus="autofocus">
+        <input name="date" type="text" class="form-control input--xlarge" placeholder="<%= __('global.search_date') %>" autofocus="autofocus">
     </form>
     <h5 class="archive-result text-color-base text-xlarge"></h5>
     <section class="boxes">
@@ -32,10 +32,10 @@
                     </h5>
                 <% lastMonth = currentMonth; %>
             <% } %>
-                <li class="archive-post archive-day" data-date="<%= post.date.format('YYYYMMDD') %>">
-                    <a class="archive-post-title" href="<%- url_for(post.path) %>"><%= post.title || '(no title)' %></a>
-                    <span class="archive-post-date"><%= ' - ' + post.date.format('DD/MM/YYYY').toLowerCase() %></span>
-                </li>
+            <li class="archive-post archive-day" data-date="<%= post.date.format('YYYYMMDD') %>">
+                <a class="archive-post-title" href="<%- url_for(post.path) %>"><%= post.title || '(' + __('post.no_title') + ')' %></a>
+                <span class="archive-post-date"><%= ' - ' + post.date.locale(page.lang).format(__('date_format')).toLowerCase() %></span>
+            </li>
         <% }) %>
     </section>
 </div>


### PR DESCRIPTION
Missing i18n in archive-post.ejs.  
Besides, I created a branch to implement the feature about making the typography to be more customizable (related to #72). [Have a look](https://github.com/h404bi/tranquilpeak-hexo-theme/commit/9de4704cc369c89ff1a3ccb1ff8fa326a6077e06)!