### PR TITLE
Fix the bug causing failure of (other plugins') file traversal

### DIFF
--- a/scripts/tags/image.js
+++ b/scripts/tags/image.js
@@ -101,3 +101,5 @@ hexo.extend.tag.register('image', function(args) {
 
     return html;
 });
+
+delete Array.prototype.reIndexOf;


### PR DESCRIPTION
When using this theme together with `hexo-qiniu-sync`, which is a deployer plugin for a Chinese CDN provider, I encountered the problem that it crashed whenever the sync process begin. However, this bug does not fire when switched to other themes.

After adding some log outputs, I found there may be something wrong with the `for` loop. here's the code segment.
```js
/**
 * 遍历目录进行上传
 */
var sync = function (dir) {
    if (!dir) {
        dir='';
        log.i('Now start qiniu sync.'.yellow);
    }
var files = fs.readdirSync(path.join(local_dir, dir));
for(i in files) {
    log.i(i, files, files[i]);     // log output
    var fname = path.join(local_dir, dir, files[i]);
    var stat = fs.lstatSync(fname);
    if(stat.isDirectory() == true) {
        sync(path.join(dir, files[i]));
    } else  {
        var name = path.join(dirPrefix, fname.replace(local_dir, '')).replace(/\\/g, '/').replace(/^\//g, '');
        check_upload(fname,name);
    }
}
};
```
With the output
```
INFO  Now start qiniu sync.
INFO  0 [ '2015', 'archives', 'assets', 'css', 'images', 'index.html', 'js' ] 2015
INFO  0 [ '11' ] 11
INFO  0 [ '04' ] 04
INFO  0 [ 'hello-world' ] hello-world
INFO  0 [ 'index.html' ] index.html
INFO  reIndexOf [ 'index.html' ] function (rx) {
        for (var i in this) {
            if (this[i].toString().match(rx)) {
                return i;
            }
        }
        return -1;
    }
FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
TypeError: Arguments to path.join must be strings
    at Object.posix.join (path.js:488:13)
    at sync (///hexo-root-dir///node_modules/hexo-qiniu-sync/sync.js:111:26)
...
```
After greping the whole directory, I found `Array.prototype.reIndexOf` is only used in this file only once but is defined in global scope, causing weird bug of other functions. 
To be frank, I've never programmed javascript. :flushed: But to my little coding experience, remove it should be good. In fact it worked. 
I guess this would also affect other plugins that tried to traverse the whole directory..maybe :smiley_cat: 